### PR TITLE
Refactor and NA handling for 'decode()'

### DIFF
--- a/inst/include/googlePolylines.h
+++ b/inst/include/googlePolylines.h
@@ -41,7 +41,11 @@ std::vector<std::string> split(const std::string &s, char delim);
 
 Rcpp::CharacterVector getSfClass(SEXP sf);
 
-Rcpp::DataFrame decode_polyline(std::string encoded, std::string encoded_type);
+Rcpp::DataFrame decode_polyline(std::string encoded, std::vector<std::string>& col_headers);
+
+std::vector<std::string> get_col_headers(Rcpp::String sfg_dim);
+
+Rcpp::DataFrame na_dataframe(std::vector<std::string>& col_headers);
 
 Rcpp::String EncodeNumber(int num);
 

--- a/inst/include/googlePolylines.h
+++ b/inst/include/googlePolylines.h
@@ -41,11 +41,14 @@ std::vector<std::string> split(const std::string &s, char delim);
 
 Rcpp::CharacterVector getSfClass(SEXP sf);
 
-Rcpp::DataFrame decode_polyline(std::string encoded, std::vector<std::string>& col_headers);
+Rcpp::List decode_polyline(std::string encoded, 
+                           std::vector<std::string>& col_headers, 
+                           std::vector<double>& pointsLat, 
+                           std::vector<double>& pointsLon);
 
 std::vector<std::string> get_col_headers(Rcpp::String sfg_dim);
 
-Rcpp::DataFrame na_dataframe(std::vector<std::string>& col_headers);
+Rcpp::List na_dataframe(std::vector<std::string>& col_headers);
 
 Rcpp::String EncodeNumber(int num);
 

--- a/inst/include/googlePolylines.h
+++ b/inst/include/googlePolylines.h
@@ -50,9 +50,9 @@ std::vector<std::string> get_col_headers(Rcpp::String sfg_dim);
 
 Rcpp::List na_dataframe(std::vector<std::string>& col_headers);
 
-Rcpp::String EncodeNumber(int num);
+void EncodeNumber(std::ostringstream& os, int num);
 
-Rcpp::String EncodeSignedNumber(int num);
+void EncodeSignedNumber(std::ostringstream& os, int num);
 
 Rcpp::String encode_polyline(Rcpp::NumericVector latitude,
                              Rcpp::NumericVector longitude);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -31,13 +31,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_decode_polyline
-Rcpp::List rcpp_decode_polyline(Rcpp::StringVector encodedStrings, std::string encoded_type);
+Rcpp::List rcpp_decode_polyline(Rcpp::StringVector encodedStrings, Rcpp::String encoded_type);
 RcppExport SEXP _googlePolylines_rcpp_decode_polyline(SEXP encodedStringsSEXP, SEXP encoded_typeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::StringVector >::type encodedStrings(encodedStringsSEXP);
-    Rcpp::traits::input_parameter< std::string >::type encoded_type(encoded_typeSEXP);
+    Rcpp::traits::input_parameter< Rcpp::String >::type encoded_type(encoded_typeSEXP);
     rcpp_result_gen = Rcpp::wrap(rcpp_decode_polyline(encodedStrings, encoded_type));
     return rcpp_result_gen;
 END_RCPP

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -78,7 +78,7 @@ void make_type(const char *cls, int *tp = NULL,
   else if (strcmp(cls, "GEOMETRY") == 0)
     type = SF_Geometry;
   else if (strcmp(cls, "GEOMETRYCOLLECTION") == 0)
-  	type = SF_GeometryCollection;
+    type = SF_GeometryCollection;
   else
     type = SF_Unknown;
   if (tp != NULL)
@@ -135,8 +135,8 @@ void encode_points( std::ostringstream& os, std::ostringstream& oszm, Rcpp::Nume
   Rcpp::NumericVector pointLon;
   Rcpp::NumericVector pointLat;
   
-  Rcpp::NumericVector elev(1);
-  Rcpp::NumericVector meas(1);
+  //Rcpp::NumericVector elev(1);
+  //Rcpp::NumericVector meas(1);
   
   for (int i = 0; i < n; i++){
     pointLon = point(i, 0);

--- a/tests/testthat/test-Decode.R
+++ b/tests/testthat/test-Decode.R
@@ -13,6 +13,11 @@ test_that("decode works", {
   expect_error(decode(data.frame()),"I don't know how to decode this object")
 })
 
+test_that("NA inputs handled properly", {
+  expect_equal(decode(NA_character_), 
+               list(data.frame("lat" = NA_real_, "lon" = NA_real_)))
+})
+
 
 # test_that("decoding ZM columns", {
 #   


### PR DESCRIPTION
The first commit is in reference to issue [#34](https://github.com/SymbolixAU/googlePolylines/issues/34), initial commit to allow `decode()` to handle `NA` input. Also added a test to `test-Decode.R`.

Previous code:
```r
polylines <- c(
  "ohlbDnbmhN~suq@am{tAw`qsAeyhGvkz`@fge}A",
  NA_character_, 
  "ggmnDt}wmLgc`DesuQvvrLofdDorqGtzzV"
)

googlePolylines::decode(polylines)
#> [[1]]
#>      lat       lon
#> 1 26.774 -80.18999
#> 2 18.466 -66.11799
#> 3 32.321 -64.75700
#> 4 26.774 -80.18999

#> [[2]]
#>   lat lon
#> 1 -8e-05 1e-05

#> [[3]]
#>      lat       lon
#> 1 28.745 -70.57899
#> 2 29.570 -67.51400
#> 3 27.339 -66.66800
#> 4 28.745 -70.57899
```
Updated code:
```r
polylines <- c(
  "ohlbDnbmhN~suq@am{tAw`qsAeyhGvkz`@fge}A",
  NA_character_, 
  "ggmnDt}wmLgc`DesuQvvrLofdDorqGtzzV"
)

googlePolylines::decode(polylines)
#> [[1]]
#>      lat       lon
#> 1 26.774 -80.18999
#> 2 18.466 -66.11799
#> 3 32.321 -64.75700
#> 4 26.774 -80.18999

#> [[2]]
#>   lat lon
#> 1  NA  NA

#> [[3]]
#>      lat       lon
#> 1 28.745 -70.57899
#> 2 29.570 -67.51400
#> 3 27.339 -66.66800
#> 4 28.745 -70.57899
```

For the `encode()` cases from issue #34, I'm happy to contribute PR's for them as well. I just really don't know enough about how `mapdeck` uses `googlePolylines::encode()` to suggest a best solution though.