### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/inst/i/b/multiprecision/cpp_int/literals.hpp
+++ b/inst/i/b/multiprecision/cpp_int/literals.hpp
@@ -236,14 +236,14 @@ struct unsigned_cpp_int_literal_result_type
 } // namespace detail
 
 template <char... STR>
-constexpr typename boost::multiprecision::literals::detail::signed_cpp_int_literal_result_type<static_cast<unsigned>((sizeof...(STR)) - 2u)>::number_type operator"" _cppi()
+constexpr typename boost::multiprecision::literals::detail::signed_cpp_int_literal_result_type<static_cast<unsigned>((sizeof...(STR)) - 2u)>::number_type operator""_cppi()
 {
    using pt = typename boost::multiprecision::literals::detail::make_packed_value_from_str<STR...>::type;
    return boost::multiprecision::literals::detail::make_backend_from_pack<pt, typename boost::multiprecision::literals::detail::signed_cpp_int_literal_result_type<static_cast<unsigned>((sizeof...(STR)) - 2u)>::backend_type>::value;
 }
 
 template <char... STR>
-constexpr typename boost::multiprecision::literals::detail::unsigned_cpp_int_literal_result_type<static_cast<unsigned>((sizeof...(STR)) - 2u)>::number_type operator"" _cppui()
+constexpr typename boost::multiprecision::literals::detail::unsigned_cpp_int_literal_result_type<static_cast<unsigned>((sizeof...(STR)) - 2u)>::number_type operator""_cppui()
 {
    using pt = typename boost::multiprecision::literals::detail::make_packed_value_from_str<STR...>::type;
    return boost::multiprecision::literals::detail::make_backend_from_pack<pt, typename boost::multiprecision::literals::detail::unsigned_cpp_int_literal_result_type<static_cast<unsigned>((sizeof...(STR)) - 2u)>::backend_type>::value;
@@ -251,7 +251,7 @@ constexpr typename boost::multiprecision::literals::detail::unsigned_cpp_int_lit
 
 #define BOOST_MP_DEFINE_SIZED_CPP_INT_LITERAL(Bits)                                                                                                                                                                                \
    template <char... STR>                                                                                                                                                                                                          \
-   constexpr boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<Bits, Bits, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void> > operator"" BOOST_JOIN(_cppi, Bits)()    \
+   constexpr boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<Bits, Bits, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void> > operator""_cppiBits()    \
    {                                                                                                                                                                                                                               \
       using pt = typename boost::multiprecision::literals::detail::make_packed_value_from_str<STR...>::type;                                                                                                                       \
       return boost::multiprecision::literals::detail::make_backend_from_pack<                                                                                                                                                      \
@@ -259,7 +259,7 @@ constexpr typename boost::multiprecision::literals::detail::unsigned_cpp_int_lit
           boost::multiprecision::backends::cpp_int_backend<Bits, Bits, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void> >::value;                                                                  \
    }                                                                                                                                                                                                                               \
    template <char... STR>                                                                                                                                                                                                          \
-   constexpr boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<Bits, Bits, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> > operator"" BOOST_JOIN(_cppui, Bits)() \
+   constexpr boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<Bits, Bits, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> > operator""_cppuiBits() \
    {                                                                                                                                                                                                                               \
       using pt = typename boost::multiprecision::literals::detail::make_packed_value_from_str<STR...>::type;                                                                                                                       \
       return boost::multiprecision::literals::detail::make_backend_from_pack<                                                                                                                                                      \


### PR DESCRIPTION
The space after `""` is deprecated since it creates ambiguity with reserved `_`-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

This might start throwing compiler warnings under `clang++-20`.